### PR TITLE
fix: check balances from all mints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 local.properties
 .aider*
 .vscode
+release

--- a/app/src/main/java/com/example/shellshock/SatocashWallet.java
+++ b/app/src/main/java/com/example/shellshock/SatocashWallet.java
@@ -27,6 +27,9 @@ public class SatocashWallet {
     public static String pendingProofToken;
 
     private static final String TAG = "SatocashWallet";
+    private static final int SATOCASH_MAX_MINTS = 16;
+    private static final int SATOCASH_MAX_KEYSETS = 32;
+    private static final int SATOCASH_MAX_PROOFS = 128;
 
     public SatocashWallet(SatocashNfcClient _client) {
         cardClient = _client;
@@ -52,184 +55,192 @@ public class SatocashWallet {
             }
 
             try {
-                // Step 1. Get mint
-                String mintUrl;
-                mintUrl = cardClient.exportMint(0);
-                Log.d(TAG, "Got mint URL: " + mintUrl);
+                int mintIndex = 0;
+                while (true) {
+                    // Step 1. Get mint
+                    String mintUrl;
+                    mintUrl = cardClient.exportMint(mintIndex);
+                    Log.d(TAG, "Got mint URL: " + mintUrl);
 
-                // Step 2. Get mint keysets
-                CashuHttpClient cashuHttpClient = new CashuHttpClient(new OkHttpClient(), mintUrl);
-                CompletableFuture<GetKeysetsResponse> keysetsFuture = cashuHttpClient.getKeysets();
+                    // Step 2. Get mint keysets
+                    CashuHttpClient cashuHttpClient = new CashuHttpClient(new OkHttpClient(), mintUrl);
+                    CompletableFuture<GetKeysetsResponse> keysetsFuture = cashuHttpClient.getKeysets();
 
-                // Step 3. Get information about the proofs in the card
-                List<Integer> metadataAmountInfo = cardClient.getProofInfo(
-                        SatocashNfcClient.Unit.valueOf(unit.toUpperCase()),
-                        SatocashNfcClient.ProofInfoType.METADATA_AMOUNT_EXPONENT,
-                        0,
-                        128
-                );
-                Log.d(TAG, "Got metadata amount info, size: " + metadataAmountInfo.size());
+                    // Step 3. Get information about the proofs in the card
+                    List<Integer> metadataAmountInfo = cardClient.getProofInfo(
+                            SatocashNfcClient.Unit.valueOf(unit.toUpperCase()),
+                            SatocashNfcClient.ProofInfoType.METADATA_AMOUNT_EXPONENT,
+                            0,
+                            SATOCASH_MAX_PROOFS
+                    );
+                    Log.d(TAG, "Got metadata amount info, size: " + metadataAmountInfo.size());
 
-                List<Integer> metadataKeysetIndices = cardClient.getProofInfo(
-                        SatocashNfcClient.Unit.valueOf(unit.toUpperCase()),
-                        SatocashNfcClient.ProofInfoType.METADATA_KEYSET_INDEX,
-                        0,
-                        128
-                );
-                Log.d(TAG, "Got metadata keyset indices, size: " + metadataKeysetIndices.size());
+                    List<Integer> metadataKeysetIndices = cardClient.getProofInfo(
+                            SatocashNfcClient.Unit.valueOf(unit.toUpperCase()),
+                            SatocashNfcClient.ProofInfoType.METADATA_KEYSET_INDEX,
+                            0,
+                            SATOCASH_MAX_PROOFS
+                    );
+                    Log.d(TAG, "Got metadata keyset indices, size: " + metadataKeysetIndices.size());
 
-                // Only consider unique indices from unspent proofs
-                Set<Integer> uniqueKeysetIndices = new HashSet<>(metadataKeysetIndices);
-                Log.d(TAG, "Unique keyset indices (from unspent proofs): " + uniqueKeysetIndices);
+                    // Only consider unique indices from unspent proofs
+                    Set<Integer> uniqueKeysetIndices = new HashSet<>(metadataKeysetIndices);
+                    Log.d(TAG, "Unique keyset indices (from unspent proofs): " + uniqueKeysetIndices);
 
-                // Get the actual keyset IDs from the card
-                List<SatocashNfcClient.KeysetInfo> keysetInfos = cardClient.exportKeysets(new ArrayList<>(uniqueKeysetIndices));
-                Log.d(TAG, "Got keyset infos, size: " + keysetInfos.size());
+                    // Get the actual keyset IDs from the card
+                    List<SatocashNfcClient.KeysetInfo> keysetInfos = cardClient.exportKeysets(new ArrayList<>(uniqueKeysetIndices));
+                    Log.d(TAG, "Got keyset infos, size: " + keysetInfos.size());
 
-                Map<Integer, String> keysetIndicesToIds = new HashMap<>();
-                for (SatocashNfcClient.KeysetInfo info : keysetInfos) {
-                    keysetIndicesToIds.put(info.index, info.id.toLowerCase());
-                }
-                Log.d(TAG, "Keyset indices to IDs map: " + keysetIndicesToIds);
-
-                // Wait for Mint keysets and then map them to their fee
-                GetKeysetsResponse keysetsResponse = keysetsFuture.join();
-                Map<String, Integer> keysetsFeesMap = new HashMap<>();
-                for (GetKeysetsItemResponse keyset : keysetsResponse.keysets) {
-                    keysetsFeesMap.put(keyset.keysetId, keyset.inputFee);
-                }
-                Log.d(TAG, "Got keysets fees map: " + keysetsFeesMap);
-
-                // Map getProofInfo response to dummy proofs (without the unblinded signature)
-                List<Proof> dummyProofs = new ArrayList<>();
-                for (int i = 0; i < metadataAmountInfo.size(); ++i) {
-                    // Check that it isn't spent
-                    if ((metadataAmountInfo.get(i) & 0x80) == 0) {
-                        int keysetIndex = metadataKeysetIndices.get(i);
-                        String keysetId = keysetIndicesToIds.get(keysetIndex);
-                        if (keysetId != null && keysetsFeesMap.containsKey(keysetId)) {
-                            Proof p = new Proof();
-                            p.amount = 1L << (metadataAmountInfo.get(i) & 0x7F); // Remove the spent bit
-                            p.keysetId = keysetId;
-                            dummyProofs.add(p);
-                            Log.d(TAG, "Added dummy proof: amount=" + p.amount + ", keysetId=" + p.keysetId);
-                        }
+                    Map<Integer, String> keysetIndicesToIds = new HashMap<>();
+                    for (SatocashNfcClient.KeysetInfo info : keysetInfos) {
+                        keysetIndicesToIds.put(info.index, info.id.toLowerCase());
                     }
-                }
-                Log.d(TAG, "Created dummy proofs, size: " + dummyProofs.size());
+                    Log.d(TAG, "Keyset indices to IDs map: " + keysetIndicesToIds);
 
-                // Step 3. Coin selection
-                ProofSelector selector = new ProofSelector(Optional.of(keysetsFeesMap));
-                Pair<List<Proof>, List<Proof>> selection = selector.selectProofsToSend(dummyProofs, (int)amount, true);
+                    // Wait for Mint keysets and then map them to their fee
+                    GetKeysetsResponse keysetsResponse = keysetsFuture.join();
+                    Map<String, Integer> keysetsFeesMap = new HashMap<>();
+                    for (GetKeysetsItemResponse keyset : keysetsResponse.keysets) {
+                        keysetsFeesMap.put(keyset.keysetId, keyset.inputFee);
+                    }
+                    Log.d(TAG, "Got keysets fees map: " + keysetsFeesMap);
 
-                List<Proof> sendSelection = selection.getSecond();
-                Log.d(TAG, "Selected proofs for sending, size: " + sendSelection.size());
-                Log.d(TAG, "Selected proofs: " + sendSelection.stream().map((p) -> p.amount).toList());
-                
-                if (sendSelection.isEmpty()) {
-                    throw new RuntimeException("Empty selection: couldn't select coins for this amount");
-                }
-
-                // Get amount plus fees
-                long amountWithFees = amount + FeeHelper.ComputeFee(selection.getSecond(), keysetsFeesMap);
-                long sumProofs = selection.getSecond().stream().map((p) -> p.amount).reduce(0L, Long::sum);
-
-                if (sumProofs < amountWithFees) {
-                    throw new RuntimeException("Card limit exceeded");
-                }
-
-                long changeAmount = sumProofs - amountWithFees;
-
-                // Match the selected proofs to their respective index in the card
-                List<Integer> selectedProofsIndices = new ArrayList<>();
-                for (Proof selectedProof : sendSelection) {
-                    for (int j = 0; j < metadataAmountInfo.size(); ++j) {
-                        if ((metadataAmountInfo.get(j) & 0x80) == 0) { // Not spent
-                            int keysetIndex = metadataKeysetIndices.get(j);
+                    // Map getProofInfo response to dummy proofs (without the unblinded signature)
+                    List<Proof> dummyProofs = new ArrayList<>();
+                    for (int i = 0; i < metadataAmountInfo.size(); ++i) {
+                        // Check that it isn't spent
+                        if ((metadataAmountInfo.get(i) & 0x80) == 0) {
+                            int keysetIndex = metadataKeysetIndices.get(i);
                             String keysetId = keysetIndicesToIds.get(keysetIndex);
-                            long proofAmount = 1L << (metadataAmountInfo.get(j) & 0x7F);
-                            
-                            if (proofAmount == selectedProof.amount && 
-                                selectedProof.keysetId.equals(keysetId)) {
-                                selectedProofsIndices.add(j);
-                                metadataAmountInfo.set(j, 0x80);
-                                break;
+                            if (keysetId != null && keysetsFeesMap.containsKey(keysetId)) {
+                                Proof p = new Proof();
+                                p.amount = 1L << (metadataAmountInfo.get(i) & 0x7F); // Remove the spent bit
+                                p.keysetId = keysetId;
+                                dummyProofs.add(p);
+                                Log.d(TAG, "Added dummy proof: amount=" + p.amount + ", keysetId=" + p.keysetId);
                             }
                         }
                     }
+                    Log.d(TAG, "Created dummy proofs, size: " + dummyProofs.size());
+
+                    // Step 3. Coin selection
+                    ProofSelector selector = new ProofSelector(Optional.of(keysetsFeesMap));
+                    Pair<List<Proof>, List<Proof>> selection = selector.selectProofsToSend(dummyProofs, (int)amount, true);
+
+                    List<Proof> sendSelection = selection.getSecond();
+                    Log.d(TAG, "Selected proofs for sending, size: " + sendSelection.size());
+                    Log.d(TAG, "Selected proofs: " + sendSelection.stream().map((p) -> p.amount).toList());
+                    
+                    if (sendSelection.isEmpty()) {
+                        if (mintIndex >= SATOCASH_MAX_MINTS) {
+                            throw new RuntimeException("Empty selection: not enough funds");
+                        }
+                        ++mintIndex;
+                        continue;
+                    }
+
+                    // Get amount plus fees
+                    long amountWithFees = amount + FeeHelper.ComputeFee(selection.getSecond(), keysetsFeesMap);
+                    long sumProofs = selection.getSecond().stream().map((p) -> p.amount).reduce(0L, Long::sum);
+
+                    if (sumProofs < amountWithFees) {
+                        throw new RuntimeException("Card limit exceeded");
+                    }
+
+                    long changeAmount = sumProofs - amountWithFees;
+
+                    // Match the selected proofs to their respective index in the card
+                    List<Integer> selectedProofsIndices = new ArrayList<>();
+                    for (Proof selectedProof : sendSelection) {
+                        for (int j = 0; j < metadataAmountInfo.size(); ++j) {
+                            if ((metadataAmountInfo.get(j) & 0x80) == 0) { // Not spent
+                                int keysetIndex = metadataKeysetIndices.get(j);
+                                String keysetId = keysetIndicesToIds.get(keysetIndex);
+                                long proofAmount = 1L << (metadataAmountInfo.get(j) & 0x7F);
+                                
+                                if (proofAmount == selectedProof.amount && 
+                                    selectedProof.keysetId.equals(keysetId)) {
+                                    selectedProofsIndices.add(j);
+                                    metadataAmountInfo.set(j, 0x80);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    
+                    if (selectedProofsIndices.size() != sendSelection.size()) {
+                        throw new RuntimeException("Failed to match all selected proofs to card indices");
+                    }
+                    
+                    Log.d(TAG, "Selected proof indices: " + selectedProofsIndices);
+
+                    // Step 4. Extract proofs from card
+                    List<Proof> exportedProofs = cardClient.exportProofs(selectedProofsIndices).stream().map((pf) -> {
+                        return new Proof(
+                                1L << pf.amountExponent,
+                                keysetIndicesToIds.get(pf.keysetIndex),
+                                new StringSecret(bytesToHex(pf.secret)),
+                                bytesToHex(pf.unblindedKey),
+                                Optional.empty(),
+                                Optional.empty()
+                        );
+                    }).collect(Collectors.toList());
+                    Log.d(TAG, "Exported proofs from card, size: " + exportedProofs.size());
+                    Log.d(TAG, "Exported proofs signatures: " + exportedProofs.stream().map((p) -> p.c).toList());
+
+                    // Create output amounts
+                    Pair<List<Long>, List<Long>> outputAmounts = createOutputAmounts(amount, changeAmount);
+
+                    // Create swap outputs
+                    String selectedKeysetId = keysetsResponse.keysets
+                            .stream()
+                            .filter((k) -> k.active)
+                            .min(Comparator.comparing((k) -> k.inputFee))
+                            .map(k -> k.keysetId)
+                            .orElseThrow(() -> new RuntimeException("No active keyset found"));
+                    Log.d(TAG, "Selected keyset ID for new proofs: " + selectedKeysetId);
+
+                    // Request the keys in the keyset
+                    CompletableFuture<GetKeysResponse> keysFuture = cashuHttpClient.getKeys(selectedKeysetId);
+
+                    List<Pair<BlindedMessage, Pair<StringSecret, BigInteger>>> outputsAndSecretData = Stream.concat(outputAmounts.getFirst().stream(), outputAmounts.getSecond().stream())
+                            .map((output) -> {
+                                StringSecret secret = StringSecret.random();
+                                BigInteger blindingFactor = generateRandomScalar();
+                                BlindedMessage blindedMessage = new BlindedMessage(
+                                        output,
+                                        selectedKeysetId,
+                                        pointToHex(computeB_(messageToCurve(secret.getSecret()), blindingFactor), true),
+                                        Optional.empty()
+                                );
+                                return new Pair<>(blindedMessage, new Pair<>(secret, blindingFactor));
+                            })
+                            .collect(Collectors.toList());
+
+                    // Create swap payload
+                    PostSwapRequest swapRequest = new PostSwapRequest();
+                    swapRequest.inputs = exportedProofs;
+                    swapRequest.outputs = outputsAndSecretData.stream().map(Pair::getFirst).collect(Collectors.toList());
+
+                    Log.d(TAG, "Attempting to swap proofs");
+
+                    PostSwapResponse response = cashuHttpClient.swap(swapRequest).join();
+                    GetKeysResponse keysResponse = keysFuture.join();
+
+                    Log.d(TAG, "Successfully swapped and received proofs");
+
+                    List<Proof> allProofs = constructAndVerifyProofs(response, keysResponse.keysets.get(0), outputsAndSecretData);
+
+                    Log.d(TAG, "Successfully constructed and verified proofs");
+                    List<Proof> changeProofs = allProofs.subList(0, outputAmounts.getFirst().size());
+                    List<Proof> receiveProofs = allProofs.subList(outputAmounts.getFirst().size(), allProofs.size());
+
+                    // Import changeProofs to card
+                    Map<String, Integer> keysetIdsToIndices = transposeMap(keysetIndicesToIds);
+                    importProofs(changeProofs, mintUrl, unit, keysetIdsToIndices);
+                    return new Token(receiveProofs, "sat", mintUrl).encode();
                 }
                 
-                if (selectedProofsIndices.size() != sendSelection.size()) {
-                    throw new RuntimeException("Failed to match all selected proofs to card indices");
-                }
-                
-                Log.d(TAG, "Selected proof indices: " + selectedProofsIndices);
-
-                // Step 4. Extract proofs from card
-                List<Proof> exportedProofs = cardClient.exportProofs(selectedProofsIndices).stream().map((pf) -> {
-                    return new Proof(
-                            1L << pf.amountExponent,
-                            keysetIndicesToIds.get(pf.keysetIndex),
-                            new StringSecret(bytesToHex(pf.secret)),
-                            bytesToHex(pf.unblindedKey),
-                            Optional.empty(),
-                            Optional.empty()
-                    );
-                }).collect(Collectors.toList());
-                Log.d(TAG, "Exported proofs from card, size: " + exportedProofs.size());
-                Log.d(TAG, "Exported proofs signatures: " + exportedProofs.stream().map((p) -> p.c).toList());
-
-                // Create output amounts
-                Pair<List<Long>, List<Long>> outputAmounts = createOutputAmounts(amount, changeAmount);
-
-                // Create swap outputs
-                String selectedKeysetId = keysetsResponse.keysets
-                        .stream()
-                        .filter((k) -> k.active)
-                        .min(Comparator.comparing((k) -> k.inputFee))
-                        .map(k -> k.keysetId)
-                        .orElseThrow(() -> new RuntimeException("No active keyset found"));
-                Log.d(TAG, "Selected keyset ID for new proofs: " + selectedKeysetId);
-
-                // Request the keys in the keyset
-                CompletableFuture<GetKeysResponse> keysFuture = cashuHttpClient.getKeys(selectedKeysetId);
-
-                List<Pair<BlindedMessage, Pair<StringSecret, BigInteger>>> outputsAndSecretData = Stream.concat(outputAmounts.getFirst().stream(), outputAmounts.getSecond().stream())
-                        .map((output) -> {
-                            StringSecret secret = StringSecret.random();
-                            BigInteger blindingFactor = generateRandomScalar();
-                            BlindedMessage blindedMessage = new BlindedMessage(
-                                    output,
-                                    selectedKeysetId,
-                                    pointToHex(computeB_(messageToCurve(secret.getSecret()), blindingFactor), true),
-                                    Optional.empty()
-                            );
-                            return new Pair<>(blindedMessage, new Pair<>(secret, blindingFactor));
-                        })
-                        .collect(Collectors.toList());
-
-                // Create swap payload
-                PostSwapRequest swapRequest = new PostSwapRequest();
-                swapRequest.inputs = exportedProofs;
-                swapRequest.outputs = outputsAndSecretData.stream().map(Pair::getFirst).collect(Collectors.toList());
-
-                Log.d(TAG, "Attempting to swap proofs");
-
-                PostSwapResponse response = cashuHttpClient.swap(swapRequest).join();
-                GetKeysResponse keysResponse = keysFuture.join();
-
-                Log.d(TAG, "Successfully swapped and received proofs");
-
-                List<Proof> allProofs = constructAndVerifyProofs(response, keysResponse.keysets.get(0), outputsAndSecretData);
-
-                Log.d(TAG, "Successfully constructed and verified proofs");
-                List<Proof> changeProofs = allProofs.subList(0, outputAmounts.getFirst().size());
-                List<Proof> receiveProofs = allProofs.subList(outputAmounts.getFirst().size(), allProofs.size());
-
-                // Import changeProofs to card
-                Map<String, Integer> keysetIdsToIndices = transposeMap(keysetIndicesToIds);
-                importProofs(changeProofs, mintUrl, unit, keysetIdsToIndices);
-                return new Token(receiveProofs, "SAT", mintUrl).encode();
             } catch (SatocashNfcClient.SatocashException | IOException e) {
                 throw new RuntimeException(e);
             } catch (Exception e) {


### PR DESCRIPTION
### Problem
Sometimes, the PoS errors with "insufficient funds" even though the card has enough funds in it.
This happens because we're selecting ecash from **ONLY** mint at index 0.

### Fix
If funds from first mint are insufficient, check the next, then the one after ... etc.
